### PR TITLE
Recent Typeahead uses .tt-menu

### DIFF
--- a/less/modules/typeahead.less
+++ b/less/modules/typeahead.less
@@ -5,7 +5,8 @@
 .twitter-typeahead {
   width: 100%;
 
-  .tt-dropdown-menu {
+  .tt-dropdown-menu,
+  .tt-menu  {
     width: 100%;
     margin-top: 5px;
     border: 2px solid @brand-secondary;


### PR DESCRIPTION
Older versions of Twitter typeahead use .tt-dropdown-menu. Newer version use .tt-menu. This fixes styles the drop-down menu.
